### PR TITLE
Remove inapplicable #to_str method

### DIFF
--- a/lib/dskiplist.rb
+++ b/lib/dskiplist.rb
@@ -212,10 +212,6 @@ class DSkipList
      return str 
   end  
 
-  def to_str
-    return "SkipList level #{@max_level}"
-  end
-
   def each(&block)
     self.to_a.each(&block)
   end


### PR DESCRIPTION
As [this Stack Overflow answer](http://stackoverflow.com/a/11182123/578288) says, `to_str` should only be implemented for classes that actually represent a string – not classes that just have a string representation.
